### PR TITLE
feat: shared layout & routing (#5)

### DIFF
--- a/specs/issues/1.4-shared-layout-and-routing.md
+++ b/specs/issues/1.4-shared-layout-and-routing.md
@@ -1,0 +1,85 @@
+# 1.4: Shared layout & routing
+
+**Status:** Approved
+**GitHub Issue:** #5
+**PR:** Draft
+
+---
+
+## Description
+
+Create shared layout components (Header, Navbar, Footer, Layout wrapper) and wire them into all 7 routes so every page has a consistent shell. This replaces the temporary Supabase test block in `App.vue`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Header displays logo and nav links to all main routes
+- [ ] Navbar collapses to a hamburger menu on mobile
+- [ ] Footer displays copyright and social/nav links
+- [ ] Layout wrapper wraps Header + `<slot />` + Footer
+- [ ] All 7 routes render inside the Layout (no page shows without header/footer)
+- [ ] Navigating between routes works without full page reload
+
+---
+
+## Implementation Checklist
+
+- [ ] Create Header component (logo, nav, links)
+- [ ] Create Navbar component (mobile-responsive)
+- [ ] Create Footer component (copyright, links)
+- [ ] Create Layout wrapper component
+- [ ] Apply layout to all 7 routes
+- [ ] Verify routing works (navigate between pages)
+
+---
+
+## Step-by-step Guide
+
+**Files to create/modify:**
+
+- `src/components/Header.vue` — logo + desktop nav links
+- `src/components/Navbar.vue` — mobile hamburger nav (toggle open/close)
+- `src/components/Footer.vue` — copyright year + social/nav links
+- `src/components/Layout.vue` — wrapper: Header + `<slot />` + Footer
+- `src/App.vue` — remove Supabase test block, render `<Layout><router-view /></Layout>`
+
+**Key decisions:**
+
+- Use `<slot />` in `Layout.vue` (not per-route meta) — `App.vue` wraps `<router-view />` inside `<Layout>`, so every route gets the shell automatically with zero per-route config
+- `Navbar.vue` handles only mobile toggle state; `Header.vue` imports and renders it alongside the desktop nav — keeps desktop/mobile concerns separated
+- Copyright year: use `new Date().getFullYear()` so it never goes stale
+
+**Non-obvious snippets:**
+
+```vue
+<!-- src/components/Layout.vue -->
+<template>
+  <div class="min-h-screen flex flex-col">
+    <Header />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <Footer />
+  </div>
+</template>
+```
+
+```vue
+<!-- src/App.vue — after cleanup -->
+<template>
+  <Layout>
+    <router-view />
+  </Layout>
+</template>
+```
+
+Nav links to include in Header: `/` (Home), `/about`, `/projects`, `/blog`, `/contact`.
+
+---
+
+## Notes
+
+- Remove the Supabase connection test block from `App.vue` — that was temporary scaffolding from Task 1.3.
+- Router is already configured with all 7 routes in `src/router/index.ts` — no router changes needed.
+- Use `<RouterLink>` (not `<a>`) for nav links to keep client-side navigation.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,34 +1,9 @@
 <template>
-  <div id="app">
-    <div class="p-4 bg-gray-100">
-      <h2 class="text-lg font-bold mb-2">Supabase Connection Test</h2>
-      <p>{{ message }}</p>
-    </div>
+  <Layout>
     <router-view />
-  </div>
+  </Layout>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { supabase } from './lib/supabase'
-
-const message = ref('Testing Supabase connection...')
-
-onMounted(async () => {
-  try {
-    // Test query: fetch one project
-    const { data, error } = await supabase
-      .from('projects')
-      .select('*')
-      .limit(1)
-
-    if (error) {
-      message.value = `Error: ${error.message}`
-    } else {
-      message.value = `✓ Connection successful! Projects: ${data?.length || 0}`
-    }
-  } catch (err) {
-    message.value = `Error: ${err instanceof Error ? err.message : 'Unknown error'}`
-  }
-})
+import Layout from './components/Layout.vue'
 </script>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,0 +1,34 @@
+<template>
+  <footer class="bg-white border-t border-gray-200 mt-auto">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div class="flex flex-col md:flex-row items-center justify-between gap-4">
+        <p class="text-sm text-gray-500">
+          &copy; {{ currentYear }} Hung Nguyen. All rights reserved.
+        </p>
+
+        <nav class="flex items-center gap-6">
+          <RouterLink
+            v-for="link in navLinks"
+            :key="link.to"
+            :to="link.to"
+            class="text-sm text-gray-500 hover:text-indigo-600 transition-colors"
+          >
+            {{ link.label }}
+          </RouterLink>
+        </nav>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<script setup lang="ts">
+const currentYear = new Date().getFullYear()
+
+const navLinks = [
+  { to: '/', label: 'Home' },
+  { to: '/about', label: 'About' },
+  { to: '/projects', label: 'Projects' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/contact', label: 'Contact' },
+]
+</script>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -8,7 +8,7 @@
 
         <nav class="flex items-center gap-6">
           <RouterLink
-            v-for="link in navLinks"
+            v-for="link in NAV_LINKS"
             :key="link.to"
             :to="link.to"
             class="text-sm text-gray-500 hover:text-indigo-600 transition-colors"
@@ -22,13 +22,7 @@
 </template>
 
 <script setup lang="ts">
-const currentYear = new Date().getFullYear()
+import { NAV_LINKS } from '../constants/nav'
 
-const navLinks = [
-  { to: '/', label: 'Home' },
-  { to: '/about', label: 'About' },
-  { to: '/projects', label: 'Projects' },
-  { to: '/blog', label: 'Blog' },
-  { to: '/contact', label: 'Contact' },
-]
+const currentYear = new Date().getFullYear()
 </script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,0 +1,38 @@
+<template>
+  <header class="bg-white border-b border-gray-200 sticky top-0 z-40">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between h-16">
+        <RouterLink to="/" class="flex items-center gap-2 font-bold text-xl text-gray-900 hover:text-indigo-600 transition-colors">
+          <span class="text-indigo-600">&lt;</span>Hung<span class="text-indigo-600">/&gt;</span>
+        </RouterLink>
+
+        <nav class="hidden md:flex items-center gap-1">
+          <RouterLink
+            v-for="link in navLinks"
+            :key="link.to"
+            :to="link.to"
+            class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-indigo-600 transition-colors"
+            active-class="text-indigo-600 bg-indigo-50"
+            exact-active-class="text-indigo-600 bg-indigo-50"
+          >
+            {{ link.label }}
+          </RouterLink>
+        </nav>
+
+        <Navbar />
+      </div>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import Navbar from './Navbar.vue'
+
+const navLinks = [
+  { to: '/', label: 'Home' },
+  { to: '/about', label: 'About' },
+  { to: '/projects', label: 'Projects' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/contact', label: 'Contact' },
+]
+</script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -8,7 +8,7 @@
 
         <nav class="hidden md:flex items-center gap-1">
           <RouterLink
-            v-for="link in navLinks"
+            v-for="link in NAV_LINKS"
             :key="link.to"
             :to="link.to"
             class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-indigo-600 transition-colors"
@@ -27,12 +27,5 @@
 
 <script setup lang="ts">
 import Navbar from './Navbar.vue'
-
-const navLinks = [
-  { to: '/', label: 'Home' },
-  { to: '/about', label: 'About' },
-  { to: '/projects', label: 'Projects' },
-  { to: '/blog', label: 'Blog' },
-  { to: '/contact', label: 'Contact' },
-]
+import { NAV_LINKS } from '../constants/nav'
 </script>

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="min-h-screen flex flex-col">
+    <Header />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <Footer />
+  </div>
+</template>
+
+<script setup lang="ts">
+import Header from './Header.vue'
+import Footer from './Footer.vue'
+</script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="md:hidden">
+    <button
+      @click="toggle"
+      class="p-2 rounded-md text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+      aria-label="Toggle menu"
+    >
+      <svg v-if="!isOpen" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+      <svg v-else class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+
+    <div v-if="isOpen" class="absolute top-16 left-0 right-0 bg-white shadow-lg border-t border-gray-100 z-50">
+      <nav class="flex flex-col px-4 py-3 space-y-1">
+        <RouterLink
+          v-for="link in navLinks"
+          :key="link.to"
+          :to="link.to"
+          class="px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-indigo-600"
+          active-class="text-indigo-600 bg-indigo-50"
+          @click="isOpen = false"
+        >
+          {{ link.label }}
+        </RouterLink>
+      </nav>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const navLinks = [
+  { to: '/', label: 'Home' },
+  { to: '/about', label: 'About' },
+  { to: '/projects', label: 'Projects' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/contact', label: 'Contact' },
+]
+
+const isOpen = ref(false)
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+</script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -16,7 +16,7 @@
     <div v-if="isOpen" class="absolute top-16 left-0 right-0 bg-white shadow-lg border-t border-gray-100 z-50">
       <nav class="flex flex-col px-4 py-3 space-y-1">
         <RouterLink
-          v-for="link in navLinks"
+          v-for="link in NAV_LINKS"
           :key="link.to"
           :to="link.to"
           class="px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-indigo-600"
@@ -32,14 +32,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-
-const navLinks = [
-  { to: '/', label: 'Home' },
-  { to: '/about', label: 'About' },
-  { to: '/projects', label: 'Projects' },
-  { to: '/blog', label: 'Blog' },
-  { to: '/contact', label: 'Contact' },
-]
+import { NAV_LINKS } from '../constants/nav'
 
 const isOpen = ref(false)
 

--- a/src/constants/nav.ts
+++ b/src/constants/nav.ts
@@ -1,0 +1,7 @@
+export const NAV_LINKS = [
+  { to: '/', label: 'Home' },
+  { to: '/about', label: 'About' },
+  { to: '/projects', label: 'Projects' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/contact', label: 'Contact' },
+] as const


### PR DESCRIPTION
## Summary

- Add `Header.vue` with logo and desktop nav links (Home, About, Projects, Blog, Contact)
- Add `Navbar.vue` with mobile hamburger toggle (hidden on md+)
- Add `Footer.vue` with copyright year (auto-updated) and nav links
- Add `Layout.vue` wrapping Header + `<slot />` + Footer
- Update `App.vue` to use Layout wrapper; remove temporary Supabase test block from Task 1.3

## Test plan

- [ ] `npm run dev` — verify page loads with header and footer
- [ ] Navigate between all 5 routes — no full page reload
- [ ] Resize to mobile — hamburger menu appears, desktop nav hides
- [ ] Tap hamburger — mobile menu opens/closes
- [ ] `npm run build` — 0 TypeScript/compile errors

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)