### PR TITLE
feat(projects): Projects list - Grid layout & fetching #15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Portfolio – Project Documentation
 
+## Project
+- Project ID: `ebcmjbcklusdjdwaaydg` (region: `ap-south-1`)
+- GitHub: https://github.com/nxhung2304/portfolio
+- Git remote: git@github.com:nxhung2304/portfolio.git
+
 ## Tech Stack
 
 - **Vue 3** – UI framework (Composition API + `<script setup>`)
@@ -48,11 +53,6 @@ Runtime config is loaded from `.env.local` (gitignored — never commit this fil
 Variables **must** use the `VITE_` prefix so Vite exposes them to the client bundle. A plain `SUPABASE_URL` without the prefix is `undefined` at runtime.
 
 For Vercel deployments, set these in **Settings → Environment Variables** for all three environments (Production, Preview, Development). Vercel does not read `.env.local` from the repo.
-
-## Supabase Notes
-
-- Project ID: `ebcmjbcklusdjdwaaydg` (region: `ap-south-1`)
-- GitHub: https://github.com/nxhung2304/portfolio
 
 ## Vercel Deployment
 

--- a/specs/comments/code-review-branch.md
+++ b/specs/comments/code-review-branch.md
@@ -1,0 +1,79 @@
+# Code Review: Current Branch
+
+## Context
+- Branch: HEAD (detached, latest commit `52c3000`)
+- Commit: `feat(projects): implement projects list page with grid layout and supabase fetching`
+- Files changed:
+  - `AGENTS.md` — documentation reorganisation (non-code)
+  - `specs/issues/3.1-projects-list-grid-layout-and-fetching.md` — spec/issue file (non-code)
+  - `src/lib/database.types.ts` — added `slug`, `thumbnail_url`, `tags` fields to `projects` table types
+  - `src/components/ProjectCard.vue` — new card component
+  - `src/pages/Projects.vue` — replaced placeholder with full implementation
+
+---
+
+## Passed
+- Supabase client is imported from `src/lib/supabase.ts` singleton — follows project convention.
+- Vue 3 Composition API with `<script setup lang="ts">` — correct pattern throughout.
+- `ref<Project[]>([])` and explicit type annotations used consistently.
+- `onMounted` triggers fetch on page load — correct lifecycle usage.
+- Error is caught and propagated; retry button calls `fetchProjects` again — good UX.
+- `loading`, `error`, empty state, and grid state are mutually exclusive via `v-if / v-else-if / v-else` — no overlapping render conditions.
+- `ProjectCard` receives full typed `Project` prop — no loose `any` in the component itself.
+- Router uses named route `project-detail` and `Projects.vue` route is lazy-loaded — consistent with other routes.
+- Tailwind grid `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` is mobile-first and matches the spec.
+- Skeleton loading matches card structure (aspect-video, title, body lines, tag pills) — good shimmer UX.
+- `aria-hidden="true"` on the placeholder emoji in `ProjectCard` — correct accessibility.
+- `database.types.ts` is updated in sync with the actual columns being queried.
+
+---
+
+## Issues
+
+### TypeScript / Type Safety
+
+- `src/pages/Projects.vue:78` — `error` ref is typed `ref<any>(null)`. This loses all type information. Use `ref<Error | null>(null)` (or `ref<PostgrestError | null>(null)` from `@supabase/supabase-js`) and cast appropriately in the catch block.
+  ```ts
+  // before
+  const error = ref<any>(null)
+  // after
+  import type { PostgrestError } from '@supabase/supabase-js'
+  const error = ref<PostgrestError | Error | null>(null)
+  ```
+
+- `src/pages/Projects.vue:87` — The `.select(...)` string selects `id, title, slug, description, thumbnail_url, tags, created_at` (7 columns) but **omits `updated_at`**. The `Project` type (full `Row`) includes `updated_at: string`, so `data` will be typed as `Project[]` while actually missing that field at runtime. Either select `*`, or narrow the local type to only the fetched columns to avoid a type/runtime mismatch.
+  ```ts
+  // Option A — select all
+  .select('*')
+  // Option B — narrow type
+  type ProjectListItem = Pick<Project, 'id' | 'title' | 'slug' | 'description' | 'thumbnail_url' | 'tags' | 'created_at'>
+  const projects = ref<ProjectListItem[]>([])
+  ```
+
+- `src/components/ProjectCard.vue:48` — `Project` type is redefined locally (duplicating the same `type Project = Database[...]` already declared in `Projects.vue`). Extract this shared type to `src/lib/database.types.ts` or a dedicated `src/types/project.ts` to avoid divergence.
+
+### Supabase Query
+
+- `src/pages/Projects.vue:87-88` — The diff in the commit shows `.select('id, title, slug, description, thumbnail_url, tags, created_at, updated_at')` but the actual file on disk reads `.select('id, title, slug, description, thumbnail_url, tags, created_at')` (without `updated_at`). This is inconsistent with the `Row` type. See type-safety issue above.
+
+### Security
+
+- `src/components/ProjectCard.vue:10` — `thumbnail_url` is rendered directly in an `<img src>` tag coming from the database. If the Supabase row is ever populated with a `javascript:` URI or a data URI, browsers will load it. Validate or sanitise `thumbnail_url` at insert time (DB constraint / check constraint `thumbnail_url LIKE 'https://%'`) and/or add a Content Security Policy `img-src` directive. No code change needed in the component itself if handled at DB/CSP level, but this is a risk to document.
+
+### Clean Code
+
+- `src/pages/Projects.vue:100-102` — `onMounted(() => { fetchProjects() })` can be simplified to `onMounted(fetchProjects)` since the callback signature matches exactly.
+
+- `src/pages/Projects.vue:66-72` — SEO meta is minimal: `og:description` and `og:image` are missing while `og:title` is present. The About page sets more complete OG tags. For consistency (and actual social sharing), add at minimum `og:description`.
+
+### Accessibility
+
+- `src/pages/Projects.vue:29` and `src/pages/Projects.vue:43` — The emoji icons inside the error/empty-state containers (`⚠️`, `🔍`) are rendered as raw text nodes, not wrapped in a `<span aria-hidden="true">`. Screen readers will announce these as emoji character names. Add `aria-hidden="true"` as was correctly done in `ProjectCard.vue`.
+
+- `src/pages/Projects.vue:32-37` — The retry `<button>` has no `type="button"` attribute. Inside a `<main>` (not a `<form>`) this is harmless, but adding `type="button"` is an explicit best practice to prevent accidental form submission if the DOM structure changes.
+
+---
+
+## Summary
+
+The implementation is solid overall: Supabase fetch, loading/error/empty states, responsive grid, and the `ProjectCard` component are all well-structured and follow project conventions. The two main issues to address before merging are the `ref<any>` error type (replace with a concrete type) and the select-vs-Row type mismatch (`updated_at` is in the type but not fetched), which will cause a silent runtime discrepancy. Accessibility gaps on the emoji icons and the missing `og:description` meta tag are minor but straightforward to fix.

--- a/specs/issues/3.1-projects-list-grid-layout-and-fetching.md
+++ b/specs/issues/3.1-projects-list-grid-layout-and-fetching.md
@@ -1,0 +1,64 @@
+## **Status:**
+- Review: Approved
+- PR: Draft #15
+
+## Metadata
+- **Title:** Projects list - Grid layout & fetching
+- **Phase:** 3 - Projects Page
+- **GitHub Issue:** #15
+
+---
+
+## Description
+Create the `/projects` route with a `ProjectList.vue` page that fetches all projects from Supabase and displays them in a responsive grid. Each card shows thumbnail, title, short description, and tech tags.
+
+---
+
+## Acceptance Criteria
+- [ ] `/projects` route renders `ProjectList.vue`
+- [ ] Projects are fetched from Supabase `projects` table on mount
+- [ ] Each project card displays: thumbnail, title, short description, tech tags
+- [ ] Grid is mobile-first responsive (1 col → 2 col → 3 col)
+- [ ] Loading state is shown while fetching data
+- [ ] Empty state is handled if no projects exist
+
+---
+
+## Implementation Checklist
+- [ ] Create `src/pages/ProjectList.vue`
+- [ ] Register `/projects` route in `src/router/index.ts`
+- [ ] Fetch projects using the Supabase client from `src/lib/supabase.ts`
+- [ ] Build `ProjectCard` component (or inline card markup)
+- [ ] Implement responsive Tailwind grid
+- [ ] Add loading skeleton or spinner while fetching
+
+---
+
+## Step-by-step Guide
+
+**Files to create/modify:**
+- `src/pages/ProjectList.vue` — main page: fetch + render grid
+- `src/router/index.ts` — add `{ path: '/projects', component: ProjectList }`
+- `src/components/ProjectCard.vue` — optional, extract card if reused on Home
+
+**Key decisions:**
+- Use `ref<Project[]>([])` + `ref(true)` for loading state; fetch in `onMounted`
+- Select only needed columns: `id, title, slug, description, thumbnail_url, tags`
+- Tags stored as `text[]` in Supabase — render each tag as a pill badge
+- Grid classes: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6`
+
+**Non-obvious snippets** *(only if needed)*:
+```ts
+// Supabase fetch — select specific columns, order by created_at
+const { data, error } = await supabase
+  .from('projects')
+  .select('id, title, slug, description, thumbnail_url, tags')
+  .order('created_at', { ascending: false })
+```
+
+---
+
+## Notes
+- `tags` column is `text[]`; use `v-for="tag in project.tags"` to render pill badges
+- If `thumbnail_url` is null, show a placeholder div with bg color
+- This page is a prerequisite for Task 3.2 (project detail page) — slug must be included in the fetch

--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -43,9 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Database } from '../lib/database.types'
-
-type Project = Database['public']['Tables']['projects']['Row']
+import type { Project } from '../lib/database.types'
 
 defineProps<{
   project: Project

--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -1,0 +1,53 @@
+<template>
+  <router-link
+    :to="{ name: 'project-detail', params: { slug: project.slug } }"
+    class="group block p-4 rounded-2xl border border-gray-200 bg-white hover:border-blue-400 hover:-translate-y-1 transition-all duration-300"
+  >
+    <!-- Thumbnail -->
+    <div class="relative aspect-video mb-4 overflow-hidden rounded-xl bg-gray-100">
+      <img
+        v-if="project.thumbnail_url"
+        :src="project.thumbnail_url"
+        :alt="project.title"
+        class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+      />
+      <div
+        v-else
+        class="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 text-gray-300"
+      >
+        <span class="text-4xl" aria-hidden="true">🖼️</span>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div>
+      <h3 class="text-lg font-bold text-gray-900 group-hover:text-blue-500 transition-colors duration-300 mb-2">
+        {{ project.title }}
+      </h3>
+      <p class="text-sm text-gray-500 line-clamp-2 mb-4 leading-relaxed">
+        {{ project.description }}
+      </p>
+
+      <!-- Tags -->
+      <div class="flex flex-wrap gap-1.5 mt-auto">
+        <span
+          v-for="tag in project.tags"
+          :key="tag"
+          class="px-2 py-0.5 rounded-md bg-gray-50 border border-gray-100 text-[10px] font-bold uppercase tracking-wider text-gray-400 group-hover:border-blue-200 group-hover:bg-blue-50 group-hover:text-blue-500 transition-all duration-300"
+        >
+          {{ tag }}
+        </span>
+      </div>
+    </div>
+  </router-link>
+</template>
+
+<script setup lang="ts">
+import type { Database } from '../lib/database.types'
+
+type Project = Database['public']['Tables']['projects']['Row']
+
+defineProps<{
+  project: Project
+}>()
+</script>

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -95,3 +95,5 @@ export type Database = {
     }
   }
 }
+
+export type Project = Database['public']['Tables']['projects']['Row']

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -9,21 +9,30 @@ export type Database = {
         Row: {
           id: string
           title: string
+          slug: string
           description: string
+          thumbnail_url: string | null
+          tags: string[]
           created_at: string
           updated_at: string
         }
         Insert: {
           id?: string
           title: string
+          slug: string
           description: string
+          thumbnail_url?: string | null
+          tags: string[]
           created_at?: string
           updated_at?: string
         }
         Update: {
           id?: string
           title?: string
+          slug?: string
           description?: string
+          thumbnail_url?: string | null
+          tags?: string[]
           created_at?: string
           updated_at?: string
         }

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -10,31 +10,40 @@ export type Database = {
           id: string
           title: string
           slug: string
-          description: string
+          description: string | null
+          content: string | null
           thumbnail_url: string | null
-          tags: string[]
+          tags: string[] | null
+          github_url: string | null
+          demo_url: string | null
+          featured: boolean
           created_at: string
-          updated_at: string
         }
         Insert: {
           id?: string
           title: string
           slug: string
-          description: string
+          description?: string | null
+          content?: string | null
           thumbnail_url?: string | null
-          tags: string[]
+          tags?: string[] | null
+          github_url?: string | null
+          demo_url?: string | null
+          featured?: boolean
           created_at?: string
-          updated_at?: string
         }
         Update: {
           id?: string
           title?: string
           slug?: string
-          description?: string
+          description?: string | null
+          content?: string | null
           thumbnail_url?: string | null
-          tags?: string[]
+          tags?: string[] | null
+          github_url?: string | null
+          demo_url?: string | null
+          featured?: boolean
           created_at?: string
-          updated_at?: string
         }
       }
       posts: {

--- a/src/pages/Projects.vue
+++ b/src/pages/Projects.vue
@@ -26,10 +26,11 @@
     <!-- Error State -->
     <div v-else-if="error" class="py-20 text-center">
       <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-50 text-red-500 mb-4">
-        ⚠️
+        <span aria-hidden="true">⚠️</span>
       </div>
       <p class="text-gray-600 mb-6">Đã có lỗi xảy ra khi tải dữ liệu. Vui lòng thử lại sau.</p>
       <button 
+        type="button"
         @click="fetchProjects"
         class="px-5 py-2 rounded-lg bg-gray-900 text-white hover:bg-black transition-all font-medium text-sm"
       >
@@ -40,7 +41,7 @@
     <!-- Empty State -->
     <div v-else-if="projects.length === 0" class="py-20 text-center">
       <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-50 text-gray-300 mb-4">
-        🔍
+        <span aria-hidden="true">🔍</span>
       </div>
       <p class="text-gray-500">Chưa có dự án nào được hiển thị.</p>
     </div>
@@ -59,8 +60,9 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useHead } from '@vueuse/head'
+import type { PostgrestError } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
-import type { Database } from '../lib/database.types'
+import type { Project } from '../lib/database.types'
 import ProjectCard from '../components/ProjectCard.vue'
 
 useHead({
@@ -68,14 +70,13 @@ useHead({
   meta: [
     { name: 'description', content: 'Portfolio của Nguyen Hung - Danh sách các dự án tiêu biểu.' },
     { property: 'og:title', content: 'Projects | Nguyen Hung' },
+    { property: 'og:description', content: 'Portfolio của Nguyen Hung - Danh sách các dự án tiêu biểu.' },
   ],
 })
 
-type Project = Database['public']['Tables']['projects']['Row']
-
 const projects = ref<Project[]>([])
 const loading = ref(true)
-const error = ref<any>(null)
+const error = ref<PostgrestError | Error | null>(null)
 
 const fetchProjects = async () => {
   try {
@@ -91,13 +92,11 @@ const fetchProjects = async () => {
     projects.value = data || []
   } catch (e) {
     console.error('Error fetching projects:', e)
-    error.value = e
+    error.value = e as PostgrestError | Error
   } finally {
     loading.value = false
   }
 }
 
-onMounted(() => {
-  fetchProjects()
-})
+onMounted(fetchProjects)
 </script>

--- a/src/pages/Projects.vue
+++ b/src/pages/Projects.vue
@@ -85,7 +85,7 @@ const fetchProjects = async () => {
     
     const { data, error: supabaseError } = await supabase
       .from('projects')
-      .select('id, title, slug, description, thumbnail_url, tags, created_at, updated_at')
+      .select('id, title, slug, description, thumbnail_url, tags, created_at')
       .order('created_at', { ascending: false })
 
     if (supabaseError) throw supabaseError

--- a/src/pages/Projects.vue
+++ b/src/pages/Projects.vue
@@ -1,13 +1,103 @@
 <template>
-  <div>
-    <h1>Projects</h1>
-    <p>My projects</p>
-  </div>
+  <main class="max-w-6xl mx-auto px-4 sm:px-8 py-12">
+    <!-- Header -->
+    <section class="mb-12">
+      <h1 class="text-3xl font-bold tracking-tight mb-4">Dự án</h1>
+      <p class="text-gray-500 max-w-2xl">
+        Danh sách các dự án cá nhân và công việc mình đã thực hiện. Mỗi dự án là một cơ hội để học hỏi và áp dụng các công nghệ mới.
+      </p>
+    </section>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div v-for="i in 6" :key="i" class="p-4 rounded-2xl border border-gray-100 bg-white animate-pulse">
+        <div class="aspect-video bg-gray-100 rounded-xl mb-4" />
+        <div class="h-6 bg-gray-100 rounded w-3/4 mb-4" />
+        <div class="h-4 bg-gray-100 rounded w-full mb-2" />
+        <div class="h-4 bg-gray-100 rounded w-5/6 mb-4" />
+        <div class="flex gap-2">
+          <div class="h-4 bg-gray-100 rounded w-12" />
+          <div class="h-4 bg-gray-100 rounded w-12" />
+          <div class="h-4 bg-gray-100 rounded w-12" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Error State -->
+    <div v-else-if="error" class="py-20 text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-50 text-red-500 mb-4">
+        ⚠️
+      </div>
+      <p class="text-gray-600 mb-6">Đã có lỗi xảy ra khi tải dữ liệu. Vui lòng thử lại sau.</p>
+      <button 
+        @click="fetchProjects"
+        class="px-5 py-2 rounded-lg bg-gray-900 text-white hover:bg-black transition-all font-medium text-sm"
+      >
+        Tải lại
+      </button>
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="projects.length === 0" class="py-20 text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-50 text-gray-300 mb-4">
+        🔍
+      </div>
+      <p class="text-gray-500">Chưa có dự án nào được hiển thị.</p>
+    </div>
+
+    <!-- Grid Layout -->
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+      <ProjectCard
+        v-for="project in projects"
+        :key="project.id"
+        :project="project"
+      />
+    </div>
+  </main>
 </template>
 
 <script setup lang="ts">
-// TODO: Fetch and display project list, add filtering and search
-</script>
+import { ref, onMounted } from 'vue'
+import { useHead } from '@vueuse/head'
+import { supabase } from '../lib/supabase'
+import type { Database } from '../lib/database.types'
+import ProjectCard from '../components/ProjectCard.vue'
 
-<style scoped>
-</style>
+useHead({
+  title: 'Projects | Nguyen Hung',
+  meta: [
+    { name: 'description', content: 'Portfolio của Nguyen Hung - Danh sách các dự án tiêu biểu.' },
+    { property: 'og:title', content: 'Projects | Nguyen Hung' },
+  ],
+})
+
+type Project = Database['public']['Tables']['projects']['Row']
+
+const projects = ref<Project[]>([])
+const loading = ref(true)
+const error = ref<any>(null)
+
+const fetchProjects = async () => {
+  try {
+    loading.value = true
+    error.value = null
+    
+    const { data, error: supabaseError } = await supabase
+      .from('projects')
+      .select('id, title, slug, description, thumbnail_url, tags, created_at, updated_at')
+      .order('created_at', { ascending: false })
+
+    if (supabaseError) throw supabaseError
+    projects.value = data || []
+  } catch (e) {
+    console.error('Error fetching projects:', e)
+    error.value = e
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  fetchProjects()
+})
+</script>


### PR DESCRIPTION
## Description
This PR implements the projects list page as part of Phase 3. It fetches project data from Supabase and displays it in a responsive grid layout.

## Changes
- Updated `src/lib/database.types.ts` with correct `projects` table columns (`slug`, `thumbnail_url`, `tags`).
- Created `src/components/ProjectCard.vue` for consistent project display.
- Overhauled `src/pages/Projects.vue` to include:
  - Data fetching from Supabase `projects` table.
  - Loading skeleton state.
  - Empty state handling.
  - Responsive grid layout (1 col mobile → 2 col sm → 3 col lg).
  - SEO metadata via `@vueuse/head`.

Closes #15