### PR TITLE
feat(projects): tag-based filtering for projects list #17

### DIFF
--- a/specs/issues/3.2-projects-list-filtering-by-technology.md
+++ b/specs/issues/3.2-projects-list-filtering-by-technology.md
@@ -1,0 +1,90 @@
+## **Status:**
+- Review: Approved
+- PR: Draft
+
+## Metadata
+- **Title:** Projects list - Filtering by technology
+- **Phase:** 3 - Projects Feature
+- **GitHub Issue:** (to be filled after sync)
+
+---
+
+## Description
+Add tag-based filtering to the existing `/projects` page (`Projects.vue`). Users can click a tech tag button to show only matching projects, and clear the filter to reset. Shows a "no results" state when the active filter matches no projects.
+
+---
+
+## Acceptance Criteria
+- [ ] All unique tech tags extracted from fetched projects and displayed as filter buttons
+- [ ] Clicking a tag button filters the project grid to show only projects with that tag
+- [ ] Active filter button is visually highlighted
+- [ ] A "Clear" / "All" button resets the filter
+- [ ] "No results" empty state is shown when no projects match the selected tag
+- [ ] Filter state resets if projects are refetched
+
+---
+
+## Implementation Checklist
+- [ ] Add `activeTag` ref to `Projects.vue`
+- [ ] Derive `uniqueTags` computed from `projects.value`
+- [ ] Add `filteredProjects` computed that filters by `activeTag`
+- [ ] Replace `v-for="project in projects"` with `v-for="project in filteredProjects"` in template
+- [ ] Build filter UI (tag buttons + "All" reset button) above the grid
+- [ ] Apply active style to selected tag button
+- [ ] Update "no results" empty state to cover both "no projects" and "no filter match" cases
+
+---
+
+## Step-by-step Guide
+
+**Files to modify:**
+- `src/pages/Projects.vue` — all changes go here; no new files needed
+
+**Key decisions:**
+- `tags` is `text[]` in Supabase — use `Set` to deduplicate across all projects
+- Filter logic is client-side computed; no extra Supabase call needed
+- Keep `filteredProjects` as a `computed`, not a separate `ref`, so it stays in sync automatically
+
+**Non-obvious snippets:**
+```ts
+const activeTag = ref<string | null>(null)
+
+const uniqueTags = computed(() =>
+  [...new Set(projects.value.flatMap(p => p.tags ?? []))].sort()
+)
+
+const filteredProjects = computed(() =>
+  activeTag.value
+    ? projects.value.filter(p => p.tags?.includes(activeTag.value!))
+    : projects.value
+)
+```
+
+Filter UI example:
+```html
+<div class="flex flex-wrap gap-2 mb-8">
+  <button
+    @click="activeTag = null"
+    :class="activeTag === null ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+    class="px-3 py-1 rounded-full text-sm font-medium transition-colors"
+  >
+    All
+  </button>
+  <button
+    v-for="tag in uniqueTags"
+    :key="tag"
+    @click="activeTag = tag"
+    :class="activeTag === tag ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+    class="px-3 py-1 rounded-full text-sm font-medium transition-colors"
+  >
+    {{ tag }}
+  </button>
+</div>
+```
+
+---
+
+## Notes
+- Replace `v-else-if="projects.length === 0"` empty state with `v-else-if="filteredProjects.length === 0"` and show different messages for "no projects" vs "no match for filter"
+- `activeTag` should reset to `null` when `fetchProjects` is called (already handled if you re-assign `projects.value`, since `filteredProjects` recomputes)
+- This task is a prerequisite for Task 3.5 (featured projects highlighting) — `filteredProjects` logic will need to remain composable

--- a/src/pages/Projects.vue
+++ b/src/pages/Projects.vue
@@ -38,18 +38,55 @@
       </button>
     </div>
 
-    <!-- Empty State -->
-    <div v-else-if="projects.length === 0" class="py-20 text-center">
+    <!-- Tag Filter -->
+    <div v-if="!loading && !error && uniqueTags.length > 0" class="flex flex-wrap gap-2 mb-8">
+      <button
+        type="button"
+        @click="activeTag = null"
+        :class="activeTag === null ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        class="px-3 py-1 rounded-full text-sm font-medium transition-colors"
+      >
+        All
+      </button>
+      <button
+        v-for="tag in uniqueTags"
+        :key="tag"
+        type="button"
+        @click="activeTag = tag"
+        :class="activeTag === tag ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        class="px-3 py-1 rounded-full text-sm font-medium transition-colors"
+      >
+        {{ tag }}
+      </button>
+    </div>
+
+    <!-- Empty State: no projects in DB -->
+    <div v-if="!loading && !error && projects.length === 0" class="py-20 text-center">
       <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-50 text-gray-300 mb-4">
         <span aria-hidden="true">🔍</span>
       </div>
       <p class="text-gray-500">Chưa có dự án nào được hiển thị.</p>
     </div>
 
+    <!-- Empty State: no match for active filter -->
+    <div v-if="!loading && !error && projects.length > 0 && filteredProjects.length === 0" class="py-20 text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-50 text-gray-300 mb-4">
+        <span aria-hidden="true">🔍</span>
+      </div>
+      <p class="text-gray-500">Không có dự án nào với tag <span class="font-medium text-gray-700">{{ activeTag ?? '' }}</span>.</p>
+      <button
+        type="button"
+        @click="activeTag = null"
+        class="mt-4 px-4 py-2 rounded-lg bg-gray-900 text-white hover:bg-black transition-all font-medium text-sm"
+      >
+        Xem tất cả
+      </button>
+    </div>
+
     <!-- Grid Layout -->
-    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+    <div v-if="!loading && !error && filteredProjects.length > 0" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
       <ProjectCard
-        v-for="project in projects"
+        v-for="project in filteredProjects"
         :key="project.id"
         :project="project"
       />
@@ -58,7 +95,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useHead } from '@vueuse/head'
 import type { PostgrestError } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
@@ -77,6 +114,17 @@ useHead({
 const projects = ref<Project[]>([])
 const loading = ref(true)
 const error = ref<PostgrestError | Error | null>(null)
+const activeTag = ref<string | null>(null)
+
+const uniqueTags = computed<string[]>(() =>
+  [...new Set(projects.value.flatMap(p => p.tags ?? []))].sort()
+)
+
+const filteredProjects = computed<Project[]>(() =>
+  activeTag.value
+    ? projects.value.filter(p => p.tags?.includes(activeTag.value!))
+    : projects.value
+)
 
 const fetchProjects = async () => {
   try {


### PR DESCRIPTION
## Summary
- Extract unique tech tags from all fetched projects and render as pill filter buttons
- Client-side filtering via `filteredProjects` computed — no extra Supabase calls
- Active tag button is visually highlighted; "All" button resets filter
- Two distinct empty states: empty DB vs no match for selected tag

## Test plan
- [ ] Navigate to `/projects` — filter buttons appear above the grid (one per unique tag + "All")
- [ ] Click a tag button — grid shows only projects with that tag; button turns dark
- [ ] Click "All" — grid resets to show all projects
- [ ] Select a tag with no projects — "no results" message appears with "Xem tất cả" button
- [ ] Click "Xem tất cả" in no-results state — resets to full grid
- [ ] If DB is empty, "Chưa có dự án nào" message shows (no filter buttons)
- [ ] `npm run lint` and `npm run build` pass with 0 errors/warnings

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)