### PR TITLE
feat: project detail page - markdown & content (#19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
         "@vueuse/head": "^2.0.0",
+        "markdown-it": "^14.1.1",
         "vue": "^3.4.0",
         "vue-router": "^4.2.5"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.19",
+        "@types/markdown-it": "^14.1.2",
         "@types/node": "^20.10.0",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
@@ -1155,6 +1158,33 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1166,6 +1196,31 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2010,7 +2065,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3342,6 +3396,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3380,6 +3443,41 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3978,6 +4076,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4537,6 +4644,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
     "@vueuse/head": "^2.0.0",
+    "markdown-it": "^14.1.1",
     "vue": "^3.4.0",
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",

--- a/specs/issues/3.3-project-detail-page-markdown-content.md
+++ b/specs/issues/3.3-project-detail-page-markdown-content.md
@@ -1,0 +1,66 @@
+## **Status:**
+- Review: Approved
+- PR: Draft
+
+## Metadata
+- **Title:** Project detail page - Markdown & content
+- **Phase:** Phase 3: Projects Feature
+- GitHub Issue: #19
+
+---
+
+## Description
+Implement the project detail page that dynamically fetches content from Supabase based on the URL slug and renders Markdown content. This ensures that project case studies can be written in Markdown and displayed beautifully.
+
+---
+
+## Acceptance Criteria
+- [x] Navigating to `/projects/[slug]` fetches the correct project from Supabase.
+- [x] Markdown content is rendered as clean HTML.
+- [x] Page displays title, tags, and creation date.
+- [x] Invalid slugs show a clear "Not Found" message or redirect to a 404 page.
+- [x] Layout is responsive and follows the project's design system.
+
+---
+
+## Implementation Checklist
+- [x] Install `markdown-it` as a dependency.
+- [x] Update `src/router/index.ts` to ensure `ProjectDetail` route accepts a `:slug` param.
+- [x] In `ProjectDetail.vue`:
+    - [x] Use `useRoute` to get the slug.
+    - [x] Fetch data from the `projects` table where `slug == route.params.slug`.
+    - [x] Implement a computed property or method to render Markdown using `markdown-it`.
+    - [x] Handle loading and error (404) states.
+- [x] Apply typography styles (consider adding `@tailwindcss/typography` if needed, or use a `prose` class wrapper).
+
+---
+
+## Step-by-step Guide
+
+**Files to create/modify:**
+- `src/pages/ProjectDetail.vue` — Implement fetching and rendering logic.
+- `src/router/index.ts` — Define the dynamic route.
+- `package.json` — Add `markdown-it`.
+
+**Key decisions:**
+- Use `markdown-it` for reliable Markdown to HTML conversion.
+- Fetch data on component mount based on the route parameter.
+- Use a simple "404 Not Found" state within the component if the project doesn't exist.
+
+**Non-obvious snippets**:
+```ts
+import MarkdownIt from 'markdown-it';
+const md = new MarkdownIt();
+
+// In setup/script setup
+const renderedContent = computed(() => {
+  return project.value ? md.render(project.value.content) : '';
+});
+```
+
+---
+
+## Notes
+- Dependency on Task 1.2 (Database schema) and Task 1.3 (Supabase client).
+- Ensure the `content` field in Supabase actually contains Markdown strings for testing.
+- Consider security: `markdown-it` is generally safe, but ensure no malicious HTML is injected if user content is ever allowed (not an issue for admin-only projects).

--- a/src/pages/ProjectDetail.vue
+++ b/src/pages/ProjectDetail.vue
@@ -1,16 +1,167 @@
 <template>
-  <div>
-    <h1>Project {{ slug }}</h1>
-    <p>Project details</p>
-  </div>
+  <main class="max-w-4xl mx-auto px-4 sm:px-8 py-12">
+    <!-- Back Button -->
+    <router-link 
+      to="/projects" 
+      class="inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-900 mb-8 transition-colors group"
+    >
+      <span class="mr-2 transform group-hover:-translate-x-1 transition-transform">←</span>
+      Back to projects
+    </router-link>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="animate-pulse">
+      <div class="h-4 bg-gray-100 rounded w-24 mb-6"></div>
+      <div class="h-10 bg-gray-100 rounded w-3/4 mb-4"></div>
+      <div class="h-6 bg-gray-100 rounded w-1/2 mb-8"></div>
+      <div class="aspect-video bg-gray-100 rounded-2xl mb-12"></div>
+      <div class="space-y-4">
+        <div class="h-4 bg-gray-100 rounded w-full"></div>
+        <div class="h-4 bg-gray-100 rounded w-full"></div>
+        <div class="h-4 bg-gray-100 rounded w-2/3"></div>
+      </div>
+    </div>
+
+    <!-- Error/Not Found State -->
+    <div v-else-if="error || !project" class="py-20 text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-50 text-red-500 mb-4">
+        <span aria-hidden="true">⚠️</span>
+      </div>
+      <h2 class="text-2xl font-bold mb-2">Project not found</h2>
+      <p class="text-gray-600 mb-8">The project you're looking for doesn't exist or has been moved.</p>
+      <router-link 
+        to="/projects"
+        class="px-6 py-2 rounded-lg bg-gray-900 text-white hover:bg-black transition-all font-medium inline-block"
+      >
+        View all projects
+      </router-link>
+    </div>
+
+    <!-- Content -->
+    <article v-else class="fade-in">
+      <header class="mb-12">
+        <div class="flex flex-wrap gap-2 mb-4">
+          <span 
+            v-for="tag in project.tags" 
+            :key="tag"
+            class="px-2 py-0.5 rounded bg-gray-100 text-gray-600 text-xs font-medium"
+          >
+            {{ tag }}
+          </span>
+        </div>
+        <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-4">{{ project.title }}</h1>
+        <p class="text-xl text-gray-500 mb-8">{{ project.description }}</p>
+        
+        <div class="flex items-center gap-6 text-sm text-gray-400">
+          <span v-if="project.created_at">
+            {{ new Date(project.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'long' }) }}
+          </span>
+          <div class="flex gap-4">
+            <a 
+              v-if="project.github_url" 
+              :href="project.github_url" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-900 transition-colors flex items-center gap-1"
+            >
+              GitHub ↗
+            </a>
+            <a 
+              v-if="project.demo_url" 
+              :href="project.demo_url" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-900 transition-colors flex items-center gap-1"
+            >
+              Live Demo ↗
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <!-- Thumbnail -->
+      <div v-if="project.thumbnail_url" class="mb-12 overflow-hidden rounded-2xl border border-gray-100">
+        <img 
+          :src="project.thumbnail_url" 
+          :alt="project.title"
+          class="w-full h-auto object-cover aspect-video"
+        />
+      </div>
+
+      <!-- Markdown Content -->
+      <div 
+        class="prose prose-gray prose-lg max-w-none prose-headings:font-bold prose-a:text-blue-600 prose-img:rounded-2xl"
+        v-html="renderedContent"
+      ></div>
+    </article>
+  </main>
 </template>
 
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { useHead } from '@vueuse/head'
+import MarkdownIt from 'markdown-it'
+import { supabase } from '../lib/supabase'
+import type { Project } from '../lib/database.types'
 
 const route = useRoute()
-const slug = route.params.slug
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true
+})
+
+const project = ref<Project | null>(null)
+const loading = ref(true)
+const error = ref<any>(null)
+
+const renderedContent = computed(() => {
+  return project.value?.content ? md.render(project.value.content) : ''
+})
+
+// Update head metadata when project data is available
+useHead(computed(() => ({
+  title: project.value ? `${project.value.title} | Nguyen Hung` : 'Project Details | Nguyen Hung',
+  meta: [
+    { name: 'description', content: project.value?.description || 'Project details' },
+    { property: 'og:title', content: project.value ? `${project.value.title} | Nguyen Hung` : 'Project Details' },
+    { property: 'og:description', content: project.value?.description || 'Project details' },
+    { property: 'og:image', content: project.value?.thumbnail_url || '' },
+  ],
+})))
+
+const fetchProject = async () => {
+  try {
+    loading.value = true
+    const slug = route.params.slug as string
+    
+    const { data, error: supabaseError } = await supabase
+      .from('projects')
+      .select('*')
+      .eq('slug', slug)
+      .single()
+
+    if (supabaseError) throw supabaseError
+    project.value = data
+  } catch (e) {
+    console.error('Error fetching project:', e)
+    error.value = e
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchProject)
 </script>
 
 <style scoped>
+.fade-in {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,5 +7,7 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }


### PR DESCRIPTION
Implement the project detail page that dynamically fetches content from Supabase based on the URL slug and renders Markdown content.

### Changes:
- Installed `markdown-it` and `@tailwindcss/typography`.
- Updated `tailwind.config.js` to include the typography plugin.
- Implemented `src/pages/ProjectDetail.vue` with:
    - Data fetching from Supabase using `useRoute` slug.
    - Markdown rendering using `markdown-it`.
    - `prose` styling for beautiful content rendering.
    - Loading and error/404 states.
    - Dynamic head metadata via `@vueuse/head`.
- Verified `ProjectCard.vue` links correctly to the detail page.

Closes #19