### PR TITLE
feat: implement tag filtering for blog list (#28)

### DIFF
--- a/specs/comments/28-code-review.md
+++ b/specs/comments/28-code-review.md
@@ -1,0 +1,21 @@
+# Code Review: Issue #28
+
+## Context
+- Branch: `feature/hung-#28-blog-list-tag-filtering`
+- Files: `src/pages/Blog.vue`
+
+## Passed
+- Logic to extract unique tags from the database is correct and efficient for a portfolio site.
+- Tag filter UI correctly follows established styling patterns (filter chips, active states).
+- Server-side filtering using Supabase `.contains` correctly implements AND logic for tags.
+- Tag filtering is correctly integrated with search and pagination (resetting page to 0).
+- "No results" state correctly handles both search and tag filters.
+- "Active Filters" UI allows easy removal of selected tags.
+
+## Issues
+- None identified. The implementation is clean and follows the project's architectural patterns.
+
+## Rules Applied
+- UI consistency with `Projects.vue`.
+- Correct use of Supabase query patterns.
+- Proper Vue 3 Composition API usage.

--- a/specs/issues/4.3-blog-list-tag-filtering.md
+++ b/specs/issues/4.3-blog-list-tag-filtering.md
@@ -1,0 +1,71 @@
+## **Status:**
+- Review: Approved
+- PR: Draft
+
+## Metadata
+- **Title:** Blog list - Tag filtering
+- **Phase:** Phase 4: Blog Feature
+- GitHub Issue: #28
+
+---
+
+## Description
+Implement tag-based filtering for the blog list. This involves extracting unique tags from all published posts, providing a UI for selecting tags, and filtering the list of posts based on the selection. It should also integrate with the existing search functionality.
+
+---
+
+## Acceptance Criteria
+- [x] Unique tags are correctly extracted from all published posts.
+- [x] A tag filter UI (e.g., clickable badges or a dropdown) is present on the blog list page.
+- [x] Clicking a tag filters the posts to only those containing that tag.
+- [x] Active filters are clearly displayed and can be removed.
+- [x] Search and tag filtering work together (AND logic).
+- [x] "No results" state is handled correctly when filters yield no matches.
+
+---
+
+## Implementation Checklist
+- [x] Implement logic to extract unique tags from the `posts` data.
+- [x] Create a filter UI (buttons/badges) for tag selection in `Blog.vue`.
+- [x] Update `Blog.vue` state to track selected tags.
+- [x] Apply filtering logic to the displayed posts list.
+- [x] Add "Active Filters" UI to show and clear selected tags.
+- [x] Ensure search input and tag filters interact correctly.
+
+---
+
+## Step-by-step Guide
+
+**Files to create/modify:**
+- `src/pages/Blog.vue` — Add tag filtering logic and UI components.
+
+**Key decisions:**
+- Use a `Set` to extract unique tags from the fetched posts list.
+- Implement filtering on the client-side for the current fetched dataset, or update the Supabase query to include `tags` filter if needed for pagination.
+- Allow multiple tags to be selected (toggle behavior).
+
+**Non-obvious snippets**:
+```ts
+// Extract unique tags
+const uniqueTags = computed(() => {
+  const tags = posts.value.flatMap(post => post.tags || []);
+  return [...new Set(tags)].sort();
+});
+
+// Combined filtering logic
+const filteredPosts = computed(() => {
+  return posts.value.filter(post => {
+    const matchesSearch = post.title.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
+                         post.excerpt?.toLowerCase().includes(searchQuery.value.toLowerCase());
+    const matchesTags = selectedTags.value.length === 0 || 
+                       selectedTags.value.every(tag => post.tags?.includes(tag));
+    return matchesSearch && matchesTags;
+  });
+});
+```
+
+---
+
+## Notes
+- If tag selection is mutually exclusive, use a simple string for `selectedTag`. If multiple tags can be selected, use an array.
+- Ensure the "Clear Filters" button appears only when filters are active.

--- a/src/pages/Blog.vue
+++ b/src/pages/Blog.vue
@@ -27,6 +27,49 @@
       </div>
     </header>
 
+    <!-- Tag Cloud -->
+    <div v-if="allTags.length > 0" class="flex flex-wrap items-center gap-2 mb-8">
+      <button
+        type="button"
+        @click="selectedTags = []"
+        :class="selectedTags.length === 0 ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        class="px-3 py-1.5 rounded-full text-xs font-medium transition-colors"
+      >
+        All Posts
+      </button>
+
+      <div class="h-4 w-px bg-gray-200 mx-1" />
+
+      <button
+        v-for="tag in allTags"
+        :key="tag"
+        type="button"
+        @click="toggleTag(tag)"
+        :class="selectedTags.includes(tag) ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        class="px-3 py-1.5 rounded-full text-xs font-medium transition-colors"
+      >
+        {{ tag }}
+      </button>
+    </div>
+
+    <!-- Active Filters -->
+    <div v-if="selectedTags.length > 0" class="flex items-center gap-2 mb-6">
+      <span class="text-xs font-bold uppercase tracking-wider text-gray-400">Active Tags:</span>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="tag in selectedTags"
+          :key="tag"
+          @click="toggleTag(tag)"
+          class="flex items-center gap-1 px-2 py-1 rounded-md bg-blue-50 border border-blue-100 text-[10px] font-bold uppercase tracking-wider text-blue-500 hover:bg-blue-100 transition-colors"
+        >
+          {{ tag }}
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
     <!-- Blog Posts Grid -->
     <div v-if="posts.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <BlogCard 
@@ -38,19 +81,19 @@
 
     <!-- Empty State / No Results -->
     <div v-else-if="!isLoading" class="text-center py-20 bg-gray-50 rounded-3xl border-2 border-dashed border-gray-200">
-      <div class="text-5xl mb-4">{{ debouncedQuery ? '🔍' : '📭' }}</div>
+      <div class="text-5xl mb-4">{{ debouncedQuery || selectedTags.length > 0 ? '🔍' : '📭' }}</div>
       <h3 class="text-xl font-bold text-gray-900 mb-2">
-        {{ debouncedQuery ? 'No results found' : 'No posts yet' }}
+        {{ debouncedQuery || selectedTags.length > 0 ? 'No results found' : 'No posts yet' }}
       </h3>
       <p class="text-gray-500">
-        {{ debouncedQuery ? `We couldn't find any posts matching "${debouncedQuery}"` : 'Check back later for new content!' }}
+        {{ debouncedQuery || selectedTags.length > 0 ? "We couldn't find any posts matching your criteria" : 'Check back later for new content!' }}
       </p>
       <button 
-        v-if="debouncedQuery"
-        @click="searchQuery = ''; debouncedQuery = ''"
+        v-if="debouncedQuery || selectedTags.length > 0"
+        @click="clearFilters"
         class="mt-6 text-blue-500 font-medium hover:underline"
       >
-        Clear search
+        Clear all filters
       </button>
     </div>
 
@@ -95,7 +138,27 @@ const pageSize = 6
 
 const searchQuery = ref('')
 const debouncedQuery = ref('')
+const selectedTags = ref<string[]>([])
+const allTags = ref<string[]>([])
 let debounceTimeout: ReturnType<typeof setTimeout> | null = null
+
+const fetchTags = async () => {
+  try {
+    const { data, error } = await supabase
+      .from('posts')
+      .select('tags')
+      .eq('published', true)
+    
+    if (error) throw error
+    
+    if (data) {
+      const tags = data.flatMap(post => post.tags || [])
+      allTags.value = [...new Set(tags)].sort()
+    }
+  } catch (error) {
+    console.error('Error fetching tags:', error)
+  }
+}
 
 const fetchPosts = async () => {
   isLoading.value = true
@@ -110,6 +173,11 @@ const fetchPosts = async () => {
 
     if (debouncedQuery.value) {
       query = query.or(`title.ilike.%${debouncedQuery.value}%,excerpt.ilike.%${debouncedQuery.value}%`)
+    }
+
+    if (selectedTags.value.length > 0) {
+      // Use contains for AND logic (must have all selected tags)
+      query = query.contains('tags', selectedTags.value)
     }
 
     const { data, count, error } = await query
@@ -138,6 +206,26 @@ const loadMore = () => {
   fetchPosts()
 }
 
+const toggleTag = (tag: string) => {
+  const index = selectedTags.value.indexOf(tag)
+  if (index === -1) {
+    selectedTags.value.push(tag)
+  } else {
+    selectedTags.value.splice(index, 1)
+  }
+}
+
+const clearFilters = () => {
+  searchQuery.value = ''
+  debouncedQuery.value = ''
+  selectedTags.value = []
+}
+
+watch(selectedTags, () => {
+  page.value = 0
+  fetchPosts()
+}, { deep: true })
+
 watch(searchQuery, (newQuery) => {
   if (debounceTimeout) clearTimeout(debounceTimeout)
   debounceTimeout = setTimeout(() => {
@@ -148,6 +236,7 @@ watch(searchQuery, (newQuery) => {
 })
 
 onMounted(() => {
+  fetchTags()
   fetchPosts()
 })
 </script>


### PR DESCRIPTION
Implement tag-based filtering for the blog list.

### Changes:
- Added tag cloud UI for selecting multiple tags.
- Implemented server-side tag filtering using Supabase `.contains` (AND logic).
- Added active filters display with the ability to remove tags.
- Integrated tag filtering with search and pagination.
- Updated empty state to handle combined filters.

Fixes #28