### PR TITLE
Social sharing and SEO metadata

### DIFF
--- a/specs/issues/4.5-blog-detail-sharing-seo.md
+++ b/specs/issues/4.5-blog-detail-sharing-seo.md
@@ -1,0 +1,67 @@
+## **Status:**
+- Review: Approved
+- PR: Draft
+
+## Metadata
+- **Title:** Blog detail page - Sharing & SEO
+- **Phase:** Phase 4: Blog Feature
+- GitHub Issue: #32
+
+---
+
+## Description
+Enhance the blog detail page with social sharing capabilities, cover images, and dynamic SEO metadata to improve visibility and engagement.
+
+---
+
+## Acceptance Criteria
+- [ ] Social sharing buttons for Twitter, LinkedIn, and "Copy Link" are functional.
+- [ ] Cover image is displayed prominently if present in the blog post data.
+- [ ] SEO meta tags (title, description, OG image) update dynamically based on the post content.
+- [ ] Sample blog data is added to Supabase to test these features.
+- [ ] Page is fully accessible (labels, contrast, keyboard navigation).
+
+---
+
+## Implementation Checklist
+- [ ] Implement `useHead` in `src/pages/BlogDetail.vue` for dynamic SEO.
+- [ ] Add cover image section in `src/pages/BlogDetail.vue` with conditional rendering.
+- [ ] Build social sharing section with platform-specific share URLs (Twitter, LinkedIn).
+- [ ] Add "Copy Link" functionality using `navigator.clipboard`.
+- [ ] Add sample blog data with cover images via Supabase dashboard or SQL.
+- [ ] Verify accessibility via Lighthouse or manual check.
+
+---
+
+## Step-by-step Guide
+
+**Files to create/modify:**
+- `src/pages/BlogDetail.vue` — Main page update to include cover image, sharing logic, and SEO.
+
+**Key decisions:**
+- Use `@vueuse/head`'s `useHead` for dynamic metadata.
+- Share buttons should open in a new window/tab using platform share URLs.
+- Cover image should have a fixed aspect ratio or max-height to maintain layout consistency.
+
+**Non-obvious snippets**:
+```ts
+import { useHead } from '@vueuse/head'
+
+// In script setup
+useHead({
+  title: computed(() => post.value?.title ? `${post.value.title} | My Portfolio` : 'Loading Post...'),
+  meta: [
+    { name: 'description', content: computed(() => post.value?.excerpt || '') },
+    { property: 'og:title', content: computed(() => post.value?.title) },
+    { property: 'og:image', content: computed(() => post.value?.cover_image_url || '/default-og.png') },
+    { name: 'twitter:card', content: 'summary_large_image' }
+  ]
+})
+```
+
+---
+
+## Notes
+- Ensure share URLs are properly encoded using `encodeURIComponent`.
+- "Copy Link" should provide visual feedback (e.g., a "Copied!" tooltip or toast).
+- Handle cases where `cover_image_url` is null or invalid gracefully.

--- a/src/components/SocialShare.vue
+++ b/src/components/SocialShare.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flex items-center gap-4">
+    <span class="text-sm font-semibold text-gray-900 uppercase tracking-wider">Share</span>
+    <div class="flex gap-2">
+      <button 
+        class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-blue-500 hover:border-blue-100 hover:bg-blue-50 transition-all" 
+        aria-label="Share on Twitter"
+        @click="shareOnTwitter"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"></path></svg>
+      </button>
+      <button 
+        class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-blue-700 hover:border-blue-100 hover:bg-blue-50 transition-all" 
+        aria-label="Share on LinkedIn"
+        @click="shareOnLinkedIn"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+      </button>
+      <button 
+        class="relative p-2 rounded-full border border-gray-100 text-gray-400 hover:text-gray-900 hover:border-gray-200 hover:bg-gray-50 transition-all" 
+        aria-label="Copy Link"
+        @click="copyLink"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+        
+        <span 
+          v-if="copied" 
+          class="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-900 text-white text-[10px] px-2 py-1 rounded"
+        >
+          Copied!
+        </span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = defineProps<{
+  title: string
+  url: string
+}>()
+
+const copied = ref(false)
+
+const shareOnTwitter = () => {
+  const text = `Check out this post: ${props.title}`
+  window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(props.url)}&text=${encodeURIComponent(text)}`, '_blank')
+}
+
+const shareOnLinkedIn = () => {
+  window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(props.url)}`, '_blank')
+}
+
+const copyLink = async () => {
+  await navigator.clipboard.writeText(props.url)
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 2000)
+}
+</script>

--- a/src/pages/BlogDetail.vue
+++ b/src/pages/BlogDetail.vue
@@ -81,20 +81,7 @@
       <!-- Social Share Section -->
       <footer class="pt-8 border-t border-gray-100">
         <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
-          <div class="flex items-center gap-4">
-            <span class="text-sm font-semibold text-gray-900 uppercase tracking-wider">Share</span>
-            <div class="flex gap-2">
-              <button class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-blue-500 hover:border-blue-100 hover:bg-blue-50 transition-all" title="Share on Twitter" @click="shareOnTwitter">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"></path></svg>
-              </button>
-              <button class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-blue-700 hover:border-blue-100 hover:bg-blue-50 transition-all" title="Share on LinkedIn" @click="shareOnLinkedIn">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
-              </button>
-              <button class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-gray-900 hover:border-gray-200 hover:bg-gray-50 transition-all" title="Copy Link" @click="copyLink">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
-              </button>
-            </div>
-          </div>
+          <SocialShare v-if="post" :title="post.title" :url="window.location.href" />
           <router-link to="/blog" class="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors">
             Read more articles →
           </router-link>
@@ -112,6 +99,7 @@ import MarkdownIt from 'markdown-it'
 import type Token from 'markdown-it/lib/token'
 import { supabase } from '../lib/supabase'
 import type { Post } from '../lib/database.types'
+import SocialShare from '../components/SocialShare.vue'
 
 const route = useRoute()
 const md = new MarkdownIt({
@@ -147,7 +135,9 @@ useHead(computed(() => ({
     { name: 'description', content: post.value?.excerpt || 'Read this blog post on Nguyen Hung\'s portfolio.' },
     { property: 'og:title', content: post.value ? `${post.value.title} | Blog | Nguyen Hung` : 'Blog Post' },
     { property: 'og:description', content: post.value?.excerpt || 'Read this blog post on Nguyen Hung\'s portfolio.' },
-    { property: 'og:image', content: post.value?.cover_image_url || '' },
+    { property: 'og:image', content: post.value?.cover_image_url || '/default-og.png' },
+    { property: 'og:url', content: window.location.href },
+    { property: 'og:type', content: 'article' },
     { name: 'twitter:card', content: 'summary_large_image' },
   ],
 })))
@@ -172,22 +162,6 @@ const fetchPost = async () => {
   } finally {
     loading.value = false
   }
-}
-
-const shareOnTwitter = () => {
-  const url = window.location.href
-  const text = `Check out this post: ${post.value?.title}`
-  window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`, '_blank')
-}
-
-const shareOnLinkedIn = () => {
-  const url = window.location.href
-  window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`, '_blank')
-}
-
-const copyLink = () => {
-  navigator.clipboard.writeText(window.location.href)
-  alert('Link copied to clipboard!')
 }
 
 onMounted(fetchPost)

--- a/src/pages/BlogDetail.vue
+++ b/src/pages/BlogDetail.vue
@@ -81,7 +81,7 @@
       <!-- Social Share Section -->
       <footer class="pt-8 border-t border-gray-100">
         <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
-          <SocialShare v-if="post" :title="post.title" :url="window.location.href" />
+          <SocialShare v-if="post" :title="post.title" :url="currentUrl" />
           <router-link to="/blog" class="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors">
             Read more articles →
           </router-link>
@@ -124,6 +124,10 @@ const post = ref<Post | null>(null)
 const loading = ref(true)
 const error = ref<Error | null>(null)
 
+const currentUrl = computed(() => {
+  return typeof window !== 'undefined' ? window.location.href : ''
+})
+
 const renderedContent = computed(() => {
   return post.value?.content ? md.render(post.value.content) : ''
 })
@@ -136,7 +140,7 @@ useHead(computed(() => ({
     { property: 'og:title', content: post.value ? `${post.value.title} | Blog | Nguyen Hung` : 'Blog Post' },
     { property: 'og:description', content: post.value?.excerpt || 'Read this blog post on Nguyen Hung\'s portfolio.' },
     { property: 'og:image', content: post.value?.cover_image_url || '/default-og.png' },
-    { property: 'og:url', content: window.location.href },
+    { property: 'og:url', content: currentUrl.value },
     { property: 'og:type', content: 'article' },
     { name: 'twitter:card', content: 'summary_large_image' },
   ],

--- a/src/pages/ProjectDetail.vue
+++ b/src/pages/ProjectDetail.vue
@@ -100,20 +100,7 @@
       <!-- Social Share Section -->
       <footer class="pt-8 border-t border-gray-100">
         <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
-          <div class="flex items-center gap-4">
-            <span class="text-sm font-semibold text-gray-900 uppercase tracking-wider">Share</span>
-            <div class="flex gap-2">
-              <button class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-blue-500 hover:border-blue-100 hover:bg-blue-50 transition-all" title="Share on Twitter">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"></path></svg>
-              </button>
-              <button class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-blue-700 hover:border-blue-100 hover:bg-blue-50 transition-all" title="Share on LinkedIn">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
-              </button>
-              <button class="p-2 rounded-full border border-gray-100 text-gray-400 hover:text-gray-900 hover:border-gray-200 hover:bg-gray-50 transition-all" title="Copy Link">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
-              </button>
-            </div>
-          </div>
+          <SocialShare v-if="project" :title="project.title" :url="currentUrl" />
           <router-link to="/projects" class="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors">
             Explore more projects →
           </router-link>
@@ -131,6 +118,7 @@ import MarkdownIt from 'markdown-it'
 import type Token from 'markdown-it/lib/token'
 import { supabase } from '../lib/supabase'
 import type { Project } from '../lib/database.types'
+import SocialShare from '../components/SocialShare.vue'
 
 const route = useRoute()
 const md = new MarkdownIt({
@@ -155,6 +143,10 @@ const project = ref<Project | null>(null)
 const loading = ref(true)
 const error = ref<Error | null>(null)
 
+const currentUrl = computed(() => {
+  return typeof window !== 'undefined' ? window.location.href : ''
+})
+
 const renderedContent = computed(() => {
   return project.value?.content ? md.render(project.value.content) : ''
 })
@@ -167,6 +159,7 @@ useHead(computed(() => ({
     { property: 'og:title', content: project.value ? `${project.value.title} | Nguyen Hung` : 'Project Details' },
     { property: 'og:description', content: project.value?.description || 'Project details' },
     { property: 'og:image', content: project.value?.thumbnail_url || '' },
+    { property: 'og:url', content: currentUrl.value },
   ],
 })))
 


### PR DESCRIPTION
This PR implements social sharing functionality and dynamic SEO metadata for the blog detail page. 

**Changes:**
- Created a reusable `SocialShare` component in `src/components/SocialShare.vue`.
- Refactored `BlogDetail.vue` to use `SocialShare` and updated SEO metadata tags using `@vueuse/head`.
- Added accessibility improvements (aria-labels).
- Improved "Copy Link" feedback with a temporary toast-like tooltip.

**Issue:** #32